### PR TITLE
Don't use os.pathsep to find EOF

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -370,7 +370,7 @@ def setquit():
     The repr of each object contains a hint at how it works.
 
     """
-    if os.sep == '\\':
+    if sys.platform == 'win32':
         eof = 'Ctrl-Z plus Return'
     else:
         eof = 'Ctrl-D (i.e. EOF)'


### PR DESCRIPTION
not all distributions in win32 have them as \
instead, check using sys.platform