### PR TITLE
Fix extension suffix for c-extensions on mingw

### DIFF
--- a/.github/workflows/smoketests.py
+++ b/.github/workflows/smoketests.py
@@ -123,6 +123,91 @@ class Tests(unittest.TestCase):
         from time import mktime, gmtime
         mktime(gmtime())
 
+    def test_c_ext_build(self):
+        import tempfile
+        import sys
+        import subprocess
+        import textwrap
+        from pathlib import Path
+
+        with tempfile.TemporaryDirectory() as tmppro:
+            subprocess.check_call([sys.executable, "-m", "ensurepip", "--user"])
+            with Path(tmppro, "setup.py").open("w") as f:
+                f.write(
+                    textwrap.dedent(
+                        """\
+                                    from setuptools import setup, Extension
+
+                                    setup(
+                                        name='cwrapper',
+                                        version='1.0',
+                                        ext_modules=[
+                                            Extension(
+                                                'cwrapper',
+                                                sources=['cwrapper.c']),
+                                        ],
+                                    )
+                                """
+                    )
+                )
+            with Path(tmppro, "cwrapper.c").open("w") as f:
+                f.write(
+                    textwrap.dedent(
+                        """\
+                                    #include <Python.h>
+                                    static PyObject *
+                                    helloworld(PyObject *self, PyObject *args)
+                                    {
+                                        printf("Hello World\\n");
+                                        return Py_None;
+                                    }
+                                    static PyMethodDef
+                                    myMethods[] = {
+                                        { "helloworld", helloworld, METH_NOARGS, "Prints Hello World" },
+                                        { NULL, NULL, 0, NULL }
+                                    };
+                                    static struct PyModuleDef cwrapper = {
+                                        PyModuleDef_HEAD_INIT,
+                                        "cwrapper",
+                                        "Test Module",
+                                        -1,
+                                        myMethods
+                                    };
+
+                                    PyMODINIT_FUNC
+                                    PyInit_cwrapper(void)
+                                    {
+                                        return PyModule_Create(&cwrapper);
+                                    }
+                                """
+                    )
+                )
+            subprocess.check_call(
+                [sys.executable, "-c", "import struct"],
+            )
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    "wheel",
+                ],
+            )
+            subprocess.check_call(
+                [
+                    sys.executable,
+                    "-m",
+                    "pip",
+                    "install",
+                    tmppro,
+                ],
+            )
+            subprocess.check_call(
+                [sys.executable, "-c", "import cwrapper"],
+            )
+
+
 
 def suite():
     return unittest.TestLoader().loadTestsFromName(__name__)

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -36,8 +36,20 @@ def get_host_platform():
 
     """
     if os.name == 'nt':
-        if 'GCC' in sys.version:
-            return 'mingw'
+        if 'gcc' in sys.version.lower():
+            if 'ucrt' in sys.version.lower():
+                if 'amd64' in sys.version.lower():
+                    return 'mingw_x86_64_ucrt'
+                return 'mingw_i686_ucrt'
+            if 'clang' in sys.version.lower():
+                if 'amd64' in sys.version.lower():
+                    return 'mingw_x86_64_clang'
+                if 'arm64' in sys.version.lower():
+                    return 'mingw_aarch64'
+                return 'mingw_i686_clang'
+            if 'amd64' in sys.version.lower():
+                return 'mingw_x86_64'
+            return 'mingw_i686'
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
         if '(arm)' in sys.version.lower():

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -667,8 +667,20 @@ def get_platform():
 
     """
     if os.name == 'nt':
-        if 'GCC' in sys.version:
-            return 'mingw'
+        if 'gcc' in sys.version.lower():
+            if 'ucrt' in sys.version.lower():
+                if 'amd64' in sys.version.lower():
+                    return 'mingw_x86_64_ucrt'
+                return 'mingw_i686_ucrt'
+            if 'clang' in sys.version.lower():
+                if 'amd64' in sys.version.lower():
+                    return 'mingw_x86_64_clang'
+                if 'arm64' in sys.version.lower():
+                    return 'mingw_aarch64'
+                return 'mingw_i686_clang'
+            if 'amd64' in sys.version.lower():
+                return 'mingw_x86_64'
+            return 'mingw_i686'
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
         if '(arm)' in sys.version.lower():

--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -165,6 +165,7 @@ CONFINCLUDEPY=	$(CONFINCLUDEDIR)/python$(LDVERSION)
 # Symbols used for using shared libraries
 SHLIB_SUFFIX=	@SHLIB_SUFFIX@
 EXT_SUFFIX=	@EXT_SUFFIX@
+PYD_PLATFORM_TAG = @PYD_PLATFORM_TAG@
 LDSHARED=	@LDSHARED@ $(PY_LDFLAGS)
 BLDSHARED=	@BLDSHARED@ $(PY_CORE_LDFLAGS)
 LDCXXSHARED=	@LDCXXSHARED@
@@ -851,8 +852,7 @@ Python/dynload_hpux.o: $(srcdir)/Python/dynload_hpux.c Makefile
 
 Python/dynload_win.o: $(srcdir)/Python/dynload_win.c Makefile
 	$(CC) -c $(PY_CORE_CFLAGS) \
-		-DSHLIB_SUFFIX='"$(SHLIB_SUFFIX)"' \
-		-DEXT_SUFFIX='"$(EXT_SUFFIX)"' \
+		-DPYD_PLATFORM_TAG='"$(PYD_PLATFORM_TAG)"' \
 		-o $@ $(srcdir)/Python/dynload_win.c
 
 Python/sysmodule.o: $(srcdir)/Python/sysmodule.c Makefile $(srcdir)/Include/pydtrace.h
@@ -1691,7 +1691,7 @@ libainstall:	@DEF_MAKE_RULE@ python-config
 	done
 	@if test -d $(LIBRARY); then :; else \
 		if test "$(PYTHONFRAMEWORKDIR)" = no-framework; then \
-			if test "$(SHLIB_SUFFIX)" = .dll; then \
+			if test "$(SHLIB_SUFFIX)" = .dll -o "$(SHLIB_SUFFIX)" = .pyd; then \
 				$(INSTALL_DATA) $(LDLIBRARY) $(DESTDIR)$(LIBPL) ; \
 			else \
 				$(INSTALL_DATA) $(LIBRARY) $(DESTDIR)$(LIBPL)/$(LIBRARY) ; \

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -27,12 +27,6 @@
 #define PYD_UNTAGGED_SUFFIX PYD_DEBUG_SUFFIX ".pyd"
 
 const char *_PyImport_DynLoadFiletab[] = {
-#ifdef EXT_SUFFIX
-    EXT_SUFFIX, /* include SOABI flags where is encoded debug */
-#endif
-#ifdef SHLIB_SUFFIX
-    "-abi" PYTHON_ABI_STRING SHLIB_SUFFIX,
-#endif
     PYD_TAGGED_SUFFIX,
     PYD_UNTAGGED_SUFFIX,
     NULL

--- a/Python/getcompiler.c
+++ b/Python/getcompiler.c
@@ -33,7 +33,11 @@
 #define COMPILER COMP_SEP "[GCC Clang " xstr(__clang_major__) "." \
         xstr(__clang_minor__) "." xstr(__clang_patchlevel__) ARCH_SUFFIX "]"
 #else
+#if defined(_UCRT)
+#define COMPILER COMP_SEP "[GCC UCRT " __VERSION__ ARCH_SUFFIX "]"
+#else
 #define COMPILER COMP_SEP "[GCC " __VERSION__ ARCH_SUFFIX "]"
+#endif
 #endif
 // Generic fallbacks.
 #elif defined(__cplusplus)

--- a/configure.ac
+++ b/configure.ac
@@ -2822,7 +2822,7 @@ if test -z "$SHLIB_SUFFIX"; then
 	*)	   SHLIB_SUFFIX=.so;;
 	esac
 	case $host_os in
-	mingw*)    SHLIB_SUFFIX=.dll;;
+	mingw*)    SHLIB_SUFFIX=.pyd;;
 	esac
 fi
 AC_MSG_RESULT($SHLIB_SUFFIX)
@@ -5095,6 +5095,67 @@ fi
 # check for endianness
 AC_C_BIGENDIAN
 
+AC_SUBST(PYD_PLATFORM_TAG)
+# Special case of PYD_PLATFORM_TAG with python build with mingw. 
+# Python can with compiled with clang or gcc and linked
+# to msvcrt or ucrt. To avoid conflicts between them
+# we are selecting the extension as based on the compiler
+# and the runtime they link to
+#   gcc + x86_64 + msvcrt = cp{version number}-x86_64
+#   gcc + i686 + msvcrt = cp{version number}-i686
+#   gcc + x86_64 + ucrt = cp{version number}-x86_64-ucrt
+#   clang + x86_64 + ucrt = cp{version number}-x86_64-clang
+#   clang + i686 + ucrt = cp{version number}-i686-clang
+
+PYD_PLATFORM_TAG=""
+case $host in
+  *-*-mingw*)
+    # check if we are linking to ucrt
+    AC_MSG_CHECKING(whether linking to ucrt)
+    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    #include <stdio.h>
+    int main(){
+      _UCRT;
+    }
+    ]])],[linking_to_ucrt=yes],[linking_to_ucrt=no])
+    AC_MSG_RESULT($linking_to_ucrt)
+    ;;
+esac
+case $host_os in
+    mingw*)
+  AC_MSG_CHECKING(PYD_PLATFORM_TAG)
+  case $host in
+  i686-*-mingw*)
+    if test -n "${cc_is_clang}"; then
+      # it is CLANG32
+      PYD_PLATFORM_TAG="mingw_i686_clang"
+    else
+      if test $linking_to_ucrt = no; then
+        PYD_PLATFORM_TAG="mingw_i686"
+      else
+        PYD_PLATFORM_TAG="mingw_i686_ucrt"
+      fi
+    fi
+    ;;
+  x86_64-*-mingw*)
+    if test -n "${cc_is_clang}"; then
+      # it is CLANG64
+      PYD_PLATFORM_TAG="mingw_x86_64_clang"
+    else
+      if test $linking_to_ucrt = no; then
+        PYD_PLATFORM_TAG="mingw_x86_64"
+      else
+        PYD_PLATFORM_TAG="mingw_x86_64_ucrt"
+      fi
+    fi
+    ;;
+  aarch64-*-mingw*)
+    PYD_PLATFORM_TAG+="mingw_aarch64"
+    ;;
+  esac
+  AC_MSG_RESULT($PYD_PLATFORM_TAG)
+esac
+
 # ABI version string for Python extension modules.  This appears between the
 # periods in shared library file names, e.g. foo.<SOABI>.so.  It is calculated
 # from the following attributes which affect the ABI of this Python build (in
@@ -5127,7 +5188,12 @@ if test "$Py_DEBUG" = 'true' -a "$with_trace_refs" != "yes"; then
 fi
 
 AC_SUBST(EXT_SUFFIX)
-EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX}
+VERSION_NO_DOTS=$(echo $LDVERSION | tr -d .)
+if test -n "${PYD_PLATFORM_TAG}"; then
+  EXT_SUFFIX=".cp${VERSION_NO_DOTS}-${PYD_PLATFORM_TAG}${SHLIB_SUFFIX}"
+else
+  EXT_SUFFIX=.${SOABI}${SHLIB_SUFFIX}
+fi
 
 AC_MSG_CHECKING(LDVERSION)
 LDVERSION='$(VERSION)$(ABIFLAGS)'
@@ -5804,12 +5870,6 @@ AC_MSG_RESULT($ac_cv_computed_gotos)
 case "$ac_cv_computed_gotos" in yes*)
   AC_DEFINE(HAVE_COMPUTED_GOTOS, 1,
   [Define if the C compiler supports computed gotos.])
-esac
-case $host_os in
-    mingw*)
-	dnl Synchronized with _PyImport_DynLoadFiletab (dynload_win.c)
-	dnl Do not use more then one dot on this platform !
-	EXT_SUFFIX=-$SOABI$SHLIB_SUFFIX;;
 esac
 
 case $ac_sys_system in


### PR DESCRIPTION
Python is compiled with various compilers which previously
had same platform tags or extension suffix. This can be error
prone while loading c-extensions, so now each compiler or
runtime has a different extension suffix.

Also, fixed a bug where `.pyd` file extensions is loaded. Python
compiled with mingw shouldn't load `.pyd` files to avoid clash with
MSVC compiled python.

Fixes msys2/MINGW-packages#8843