### PR TITLE
[1/2] AC_RUN_IFELSE replace

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -5146,11 +5146,12 @@ case $host in
   *-*-mingw*)
     # check if we are linking to ucrt
     AC_MSG_CHECKING(whether linking to ucrt)
-    AC_RUN_IFELSE([AC_LANG_SOURCE([[
+    AC_COMPILE_IFELSE([AC_LANG_SOURCE([[
     #include <stdio.h>
-    int main(){
-      _UCRT;
-    }
+    #ifndef _UCRT
+        #error no ucrt
+    #endif
+    int main(){}
     ]])],[linking_to_ucrt=yes],[linking_to_ucrt=no])
     AC_MSG_RESULT($linking_to_ucrt)
     ;;

--- a/configure.ac
+++ b/configure.ac
@@ -5151,7 +5151,7 @@ case $host in
     #ifndef _UCRT
         #error no ucrt
     #endif
-    int main(){}
+    int main(){ return 0; }
     ]])],[linking_to_ucrt=yes],[linking_to_ucrt=no])
     AC_MSG_RESULT($linking_to_ucrt)
     ;;


### PR DESCRIPTION
Progress in fixing #18 
Replaced the first `AC_RUN_IFELSE` with `AC_COMPILE_IFELSE`
The second one needs some discussion though, so I won't include it here