### PR TITLE
_testconsole.c: Fix casing & path sep

### DIFF
--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -6,7 +6,7 @@
 
 #ifdef MS_WINDOWS
 
-#include "..\modules\_io\_iomodule.h"
+#include "../Modules/_io/_iomodule.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -101,7 +101,7 @@ _testconsole_read_output_impl(PyObject *module, PyObject *file)
     Py_RETURN_NONE;
 }
 
-#include "clinic\_testconsole.c.h"
+#include "clinic/_testconsole.c.h"
 
 PyMethodDef testconsole_methods[] = {
     _TESTCONSOLE_WRITE_INPUT_METHODDEF


### PR DESCRIPTION
Fix errors when compiling on case-sensitive file systems