### PR TITLE
Set PYD_PLATFORM_TAG for armv7 targets too

### DIFF
--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -46,6 +46,8 @@ def get_host_platform():
                     return 'mingw_x86_64_clang'
                 if 'arm64' in sys.version.lower():
                     return 'mingw_aarch64'
+                if 'arm' in sys.version.lower():
+                    return 'mingw_armv7'
                 return 'mingw_i686_clang'
             if 'amd64' in sys.version.lower():
                 return 'mingw_x86_64'

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -678,6 +678,8 @@ def get_platform():
                     return 'mingw_x86_64_clang'
                 if 'arm64' in sys.version.lower():
                     return 'mingw_aarch64'
+                if 'arm' in sys.version.lower():
+                    return 'mingw_armv7'
                 return 'mingw_i686_clang'
             if 'amd64' in sys.version.lower():
                 return 'mingw_x86_64'

--- a/Python/getcompiler.c
+++ b/Python/getcompiler.c
@@ -20,6 +20,8 @@
 #define ARCH_SUFFIX " 64 bit (AMD64)"
 #elif defined(__aarch64__)
 #define ARCH_SUFFIX " 64 bit (ARM64)"
+#elif defined(__arm__)
+#define ARCH_SUFFIX " 32 bit (ARM)"
 #else
 #define ARCH_SUFFIX " 32 bit"
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -5197,6 +5197,9 @@ case $host_os in
   aarch64-*-mingw*)
     PYD_PLATFORM_TAG+="mingw_aarch64"
     ;;
+  armv7-*-mingw*)
+    PYD_PLATFORM_TAG+="mingw_armv7"
+    ;;
   esac
   AC_MSG_RESULT($PYD_PLATFORM_TAG)
 esac


### PR DESCRIPTION
This makes an armv7-mingw build of python actually find the native modules.
