### PR TITLE
fix mingw cross compiling in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -710,14 +710,25 @@ class PyBuildExt(build_ext):
                         elif line.startswith("End of search list"):
                             in_incdirs = False
                         elif (is_gcc or is_clang) and line.startswith("LIBRARY_PATH"):
-                            for d in line.strip().split("=")[1].split(":"):
+                            for d in line.strip().split("=")[1].split(os.pathsep):
                                 d = os.path.normpath(d)
-                                if '/gcc/' not in d:
+                                if '/gcc/' not in d and '/clang/' not in d:
                                     add_dir_to_list(self.compiler.library_dirs,
                                                     d)
                         elif (is_gcc or is_clang) and in_incdirs and '/gcc/' not in line and '/clang/' not in line:
                             add_dir_to_list(self.compiler.include_dirs,
                                             line.strip())
+            if is_clang:
+                ret = run_command('%s -print-search-dirs >%s' % (cc, tmpfile))
+                if ret == 0:
+                    with open(tmpfile) as fp:
+                        for line in fp.readlines():
+                            if line.startswith("libraries:"):
+                                for d in line.strip().split("=")[1].split(os.pathsep):
+                                    d = os.path.normpath(d)
+                                    if '/gcc/' not in d and '/clang/' not in d:
+                                        add_dir_to_list(self.compiler.library_dirs,
+                                                        d)
         finally:
             os.unlink(tmpfile)
 


### PR DESCRIPTION
gcc outputs with `;` path delimiter on mingw, so use `os.pathsep` instead of `:` (assuming this is a host rather than target decision)

clang does not output `LIBRARY_PATH` with `-E -v`, so add an extra call to `-print-search-dirs` to find its library path.

Fixes #58.  ncurses is still having issues, but that can wait for a different PR (#62)