### PR TITLE
Fix buffer overflow in Py_GetSepW() 

### DIFF
--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -83,10 +83,11 @@ Py_GetAltSepA(const char *name)
 void
 Py_NormalizeSepsA(char *name)
 {
+    assert(name != NULL);
     char sep = Py_GetSepA(name);
     char altsep = Py_GetAltSepA(name);
     char* seps;
-    if (strlen(name) > 1 && name[1] == ':') {
+    if (name[0] != '\0' && name[1] == ':') {
         name[0] = toupper(name[0]);
     }
     seps = strchr(name, altsep);
@@ -135,10 +136,11 @@ Py_GetAltSepW(const wchar_t *name)
 void
 Py_NormalizeSepsW(wchar_t *name)
 {
+    assert(name != NULL);
     wchar_t sep = Py_GetSepW(name);
     wchar_t altsep = Py_GetAltSepW(name);
     wchar_t* seps;
-    if (wcslen(name) > 1 && name[1] == L':') {
+    if (name[0] != L'\0' && name[1] == L':') {
         name[0] = towupper(name[0]);
     }
     seps = wcschr(name, altsep);

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -20,6 +20,30 @@ extern "C" {
 #include <windows.h>
 #endif
 
+static int
+Py_StartsWithA(const char * str, const char * prefix)
+{
+    while(*prefix)
+    {
+        if(*prefix++ != *str++)
+            return 0;
+    }
+
+    return 1;
+}
+
+static int
+Py_StartsWithW(const wchar_t * str, const wchar_t * prefix)
+{
+    while(*prefix)
+    {
+        if(*prefix++ != *str++)
+            return 0;
+    }
+
+    return 1;
+}
+
 char
 Py_GetSepA(const char *name)
 {
@@ -30,7 +54,7 @@ Py_GetSepA(const char *name)
      * The "\\?\" prefix .. indicate that the path should be passed to the system with minimal
      * modification, which means that you cannot use forward slashes to represent path separators
      */
-    if (name != NULL && memcmp(name, "\\\\?\\", sizeof("\\\\?\\") - sizeof(char)) == 0)
+    if (name != NULL && Py_StartsWithA(name, "\\\\?\\") != 0)
     {
         return '\\';
     }
@@ -82,7 +106,7 @@ Py_GetSepW(const wchar_t *name)
      * The "\\?\" prefix .. indicate that the path should be passed to the system with minimal
      * modification, which means that you cannot use forward slashes to represent path separators
      */
-    if (name != NULL && memcmp(name, L"\\\\?\\", sizeof(L"\\\\?\\") - sizeof(wchar_t)) == 0)
+    if (name != NULL && Py_StartsWithW(name, L"\\\\?\\") != 0)
     {
         return L'\\';
     }


### PR DESCRIPTION
Fixes #63 &ndash; buffer overflow found by ASAN.

Also remove unnecessary strlen() calls in Py_NormalizeSepsW().