### PR TITLE
bpo-45433: Do not link libpython against libcrypt

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -4354,6 +4354,8 @@ AC_CHECK_FUNCS(setpgrp,
 
 # We search for both crypt and crypt_r as one or the other may be defined
 # This gets us our -lcrypt in LIBS when required on the target platform.
+# Save/restore LIBS to avoid linking libpython with libcrypt.
+LIBS_SAVE=$LIBS
 AC_SEARCH_LIBS(crypt, crypt)
 AC_SEARCH_LIBS(crypt_r, crypt)
 
@@ -4368,6 +4370,7 @@ char *r = crypt_r("", "", &d);
     [AC_DEFINE(HAVE_CRYPT_R, 1, [Define if you have the crypt_r() function.])],
     [])
 )
+LIBS=$LIBS_SAVE
 
 case $host in
   *-*-mingw*) ;;


### PR DESCRIPTION
Backport https://github.com/python/cpython/pull/28881