### PR TITLE
forward port patches from mingw-v3.9.7

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -162,7 +162,16 @@ jobs:
       - name: Install deps
         run: |
           pacman --noconfirm -Suuy
-          pacman --needed --noconfirm -S mingw-w64-gcc autoconf-archive autoconf automake python zip
+          pacman --needed --noconfirm -S mingw-w64-gcc autoconf-archive autoconf automake zip
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Check Python Version
+        run: |
+          which python
+          python --version
 
       - name: Build
         run: |

--- a/Lib/distutils/cygwinccompiler.py
+++ b/Lib/distutils/cygwinccompiler.py
@@ -50,15 +50,13 @@ cygwin in no-cygwin mode).
 import os
 import sys
 import copy
-import re
 
 from distutils.unixccompiler import UnixCCompiler
 from distutils.file_util import write_file
 from distutils.errors import (DistutilsExecError, CCompilerError,
         CompileError, UnknownFileError)
-from distutils.version import LooseVersion
 from distutils.spawn import find_executable
-from subprocess import Popen, PIPE, check_output
+from subprocess import Popen, check_output
 
 def get_msvcr():
     """Include the appropriate MSVC runtime library if Python was built
@@ -115,33 +113,8 @@ class CygwinCCompiler(UnixCCompiler):
         self.cc = os.environ.get('CC', 'gcc')
         self.cxx = os.environ.get('CXX', 'g++')
 
-        if ('gcc' in self.cc): # Start gcc workaround
-            self.gcc_version, self.ld_version, self.dllwrap_version = \
-                get_versions()
-            self.debug_print(self.compiler_type + ": gcc %s, ld %s, dllwrap %s\n" %
-                             (self.gcc_version,
-                              self.ld_version,
-                              self.dllwrap_version) )
-
-            # ld_version >= "2.10.90" and < "2.13" should also be able to use
-            # gcc -mdll instead of dllwrap
-            # Older dllwraps had own version numbers, newer ones use the
-            # same as the rest of binutils ( also ld )
-            # dllwrap 2.10.90 is buggy
-            if self.ld_version >= "2.10.90":
-                self.linker_dll = self.cc
-            else:
-                self.linker_dll = "dllwrap"
-
-            # ld_version >= "2.13" support -shared so use it instead of
-            # -mdll -static
-            if self.ld_version >= "2.13":
-                shared_option = "-shared"
-            else:
-                shared_option = "-mdll -static"
-        else: # Assume linker is up to date
-            self.linker_dll = self.cc
-            shared_option = "-shared"
+        self.linker_dll = self.cc
+        shared_option = "-shared"
 
         self.set_executables(compiler='%s -mcygwin -O -Wall' % self.cc,
                              compiler_so='%s -mcygwin -mdll -O -Wall' % self.cc,
@@ -150,17 +123,9 @@ class CygwinCCompiler(UnixCCompiler):
                              linker_so=('%s -mcygwin %s' %
                                         (self.linker_dll, shared_option)))
 
-        # cygwin and mingw32 need different sets of libraries
-        if ('gcc' in self.cc and self.gcc_version == "2.91.57"):
-            # cygwin shouldn't need msvcrt, but without the dlls will crash
-            # (gcc version 2.91.57) -- perhaps something about initialization
-            self.dll_libraries=["msvcrt"]
-            self.warn(
-                "Consider upgrading to a newer version of gcc")
-        else:
-            # Include the appropriate MSVC runtime library if Python was built
-            # with MSVC 7.0 or later.
-            self.dll_libraries = get_msvcr()
+        # Include the appropriate MSVC runtime library if Python was built
+        # with MSVC 7.0 or later.
+        self.dll_libraries = get_msvcr()
 
     def _compile(self, obj, src, ext, cc_args, extra_postargs, pp_opts):
         """Compiles the source by spawning GCC and windres if needed."""
@@ -244,24 +209,17 @@ class CygwinCCompiler(UnixCCompiler):
 
             # next add options for def-file and to creating import libraries
 
-            # dllwrap uses different options than gcc/ld
-            if self.linker_dll == "dllwrap":
-                extra_preargs.extend(["--output-lib", lib_file])
-                # for dllwrap we have to use a special option
-                extra_preargs.extend(["--def", def_file])
-            # we use gcc/ld here and can be sure ld is >= 2.9.10
-            else:
-                # doesn't work: bfd_close build\...\libfoo.a: Invalid operation
-                #extra_preargs.extend(["-Wl,--out-implib,%s" % lib_file])
-                # for gcc/ld the def-file is specified as any object files
-                objects.append(def_file)
+            # doesn't work: bfd_close build\...\libfoo.a: Invalid operation
+            #extra_preargs.extend(["-Wl,--out-implib,%s" % lib_file])
+            # for gcc/ld the def-file is specified as any object files
+            objects.append(def_file)
 
         #end: if ((export_symbols is not None) and
         #        (target_desc != self.EXECUTABLE or self.linker_dll == "gcc")):
 
         # who wants symbols and a many times larger output file
         # should explicitly switch the debug mode on
-        # otherwise we let dllwrap/ld strip the output file
+        # otherwise we let ld strip the output file
         # (On my machine: 10KiB < stripped_file < ??100KiB
         #   unstripped_file = stripped_file + XXX KiB
         #  ( XXX=254 for a typical python extension))
@@ -314,19 +272,7 @@ class Mingw32CCompiler(CygwinCCompiler):
 
         CygwinCCompiler.__init__ (self, verbose, dry_run, force)
 
-        # ld_version >= "2.13" support -shared so use it instead of
-        # -mdll -static
-        if ('gcc' in self.cc and self.ld_version < "2.13"):
-            shared_option = "-mdll -static"
-        else:
-            shared_option = "-shared"
-
-        # A real mingw32 doesn't need to specify a different entry point,
-        # but cygwin 2.91.57 in no-cygwin-mode needs it.
-        if ('gcc' in self.cc and self.gcc_version <= "2.91.57"):
-            entry_point = '--entry _DllMain@12'
-        else:
-            entry_point = ''
+        shared_option = "-shared"
 
         if is_cygwincc(self.cc):
             raise CCompilerError(
@@ -336,9 +282,8 @@ class Mingw32CCompiler(CygwinCCompiler):
                              compiler_so='%s -mdll -O2 -Wall' % self.cc,
                              compiler_cxx='%s -O2 -Wall' % self.cxx,
                              linker_exe='%s' % self.cc,
-                             linker_so='%s %s %s'
-                                        % (self.linker_dll, shared_option,
-                                           entry_point))
+                             linker_so='%s %s'
+                                        % (self.linker_dll, shared_option))
         # Maybe we should also append -mthreads, but then the finished
         # dlls need another dll (mingwm10.dll see Mingw32 docs)
         # (-mthreads: Support thread-safe exception handling on `Mingw32')
@@ -405,46 +350,6 @@ def check_config_h():
         return (CONFIG_H_UNCERTAIN,
                 "couldn't read '%s': %s" % (fn, exc.strerror))
 
-RE_VERSION = re.compile(br'[\D\s]*(\d+\.\d+(\.\d+)*)[\D\s]*')
-
-def _find_exe_version(cmd):
-    """Find the version of an executable by running `cmd` in the shell.
-
-    If the command is not found, or the output does not match
-    `RE_VERSION`, returns None.
-    """
-    executable = cmd.split()[0]
-    if find_executable(executable) is None:
-        return None
-    from subprocess import Popen, PIPE
-    out = Popen(cmd, shell=True, stdout=PIPE).stdout
-    try:
-        out_string = out.read()
-    finally:
-        out.close()
-    result = RE_VERSION.search(out_string)
-    if result is None:
-        return None
-    # LooseVersion works with strings
-    # so we need to decode our bytes
-    return LooseVersion(result.group(1).decode())
-
-def get_versions():
-    """ Try to find out the versions of gcc, ld and dllwrap.
-
-    If not possible it returns None for it.
-    """
-    gcc = os.environ.get('CC') or 'gcc'
-    ld = 'ld'
-    out = Popen(gcc+' --print-prog-name ld', shell=True, stdout=PIPE).stdout
-    try:
-        ld = test=str(out.read(),encoding='utf-8').strip()
-    finally:
-        out.close()
-    dllwrap = os.environ.get('DLLWRAP') or 'dllwrap'
-    # MinGW64 doesn't have i686-w64-mingw32-ld, so instead we ask gcc.
-    commands = [gcc+' -dumpversion', ld+' -v', dllwrap+' --version']
-    return tuple([_find_exe_version(cmd) for cmd in commands])
 
 def is_cygwincc(cc):
     '''Try to determine if the compiler that would be used is from cygwin.'''

--- a/Lib/distutils/cygwinccompiler.py
+++ b/Lib/distutils/cygwinccompiler.py
@@ -56,6 +56,7 @@ from distutils.unixccompiler import UnixCCompiler
 from distutils.file_util import write_file
 from distutils.errors import (DistutilsExecError, CCompilerError,
         CompileError, UnknownFileError)
+from distutils.version import LooseVersion
 from distutils.spawn import find_executable
 from subprocess import Popen, check_output
 
@@ -113,6 +114,12 @@ class CygwinCCompiler(UnixCCompiler):
 
         self.cc = os.environ.get('CC', 'gcc')
         self.cxx = os.environ.get('CXX', 'g++')
+
+        # Older numpy dependend on this existing to check for ancient
+        # gcc versions. This doesn't make much sense with clang etc so
+        # just hardcode to something recent.
+        # https://github.com/numpy/numpy/pull/20333
+        self.gcc_version = LooseVersion("11.2.0")
 
         self.linker_dll = self.cc
         shared_option = "-shared"

--- a/Lib/distutils/cygwinccompiler.py
+++ b/Lib/distutils/cygwinccompiler.py
@@ -50,6 +50,7 @@ cygwin in no-cygwin mode).
 import os
 import sys
 import copy
+import shlex
 
 from distutils.unixccompiler import UnixCCompiler
 from distutils.file_util import write_file
@@ -353,5 +354,5 @@ def check_config_h():
 
 def is_cygwincc(cc):
     '''Try to determine if the compiler that would be used is from cygwin.'''
-    out_string = check_output([cc, '-dumpmachine'])
+    out_string = check_output(shlex.split(cc) + ['-dumpmachine'])
     return out_string.strip().endswith(b'cygwin')

--- a/Lib/distutils/tests/test_cygwinccompiler.py
+++ b/Lib/distutils/tests/test_cygwinccompiler.py
@@ -8,7 +8,7 @@ from test.support import run_unittest
 from distutils import cygwinccompiler
 from distutils.cygwinccompiler import (check_config_h,
                                        CONFIG_H_OK, CONFIG_H_NOTOK,
-                                       CONFIG_H_UNCERTAIN, get_versions,
+                                       CONFIG_H_UNCERTAIN,
                                        get_msvcr)
 from distutils.tests import support
 
@@ -80,40 +80,6 @@ class CygwinCCompilerTestCase(support.TempdirManager,
         # and CONFIG_H_OK if __GNUC__ is found
         self.write_file(self.python_h, 'xxx __GNUC__ xxx')
         self.assertEqual(check_config_h()[0], CONFIG_H_OK)
-
-    def test_get_versions(self):
-
-        # get_versions calls distutils.spawn.find_executable on
-        # 'gcc', 'ld' and 'dllwrap'
-        self.assertEqual(get_versions(), (None, None, None))
-
-        # Let's fake we have 'gcc' and it returns '3.4.5'
-        self._exes['gcc'] = b'gcc (GCC) 3.4.5 (mingw special)\nFSF'
-        res = get_versions()
-        self.assertEqual(str(res[0]), '3.4.5')
-
-        # and let's see what happens when the version
-        # doesn't match the regular expression
-        # (\d+\.\d+(\.\d+)*)
-        self._exes['gcc'] = b'very strange output'
-        res = get_versions()
-        self.assertEqual(res[0], None)
-
-        # same thing for ld
-        self._exes['ld'] = b'GNU ld version 2.17.50 20060824'
-        res = get_versions()
-        self.assertEqual(str(res[1]), '2.17.50')
-        self._exes['ld'] = b'@(#)PROGRAM:ld  PROJECT:ld64-77'
-        res = get_versions()
-        self.assertEqual(res[1], None)
-
-        # and dllwrap
-        self._exes['dllwrap'] = b'GNU dllwrap 2.17.50 20060824\nFSF'
-        res = get_versions()
-        self.assertEqual(str(res[2]), '2.17.50')
-        self._exes['dllwrap'] = b'Cheese Wrap'
-        res = get_versions()
-        self.assertEqual(res[2], None)
 
     def test_get_msvcr(self):
 

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -47,6 +47,8 @@ def get_host_platform():
                     return 'mingw_x86_64_clang'
                 if 'arm64' in sys.version.lower():
                     return 'mingw_aarch64'
+                if 'arm' in sys.version.lower():
+                    return 'mingw_armv7'
                 return 'mingw_i686_clang'
             if 'amd64' in sys.version.lower():
                 return 'mingw_x86_64'

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -731,6 +731,8 @@ def get_platform():
                     return 'mingw_x86_64_clang'
                 if 'arm64' in sys.version.lower():
                     return 'mingw_aarch64'
+                if 'arm' in sys.version.lower():
+                    return 'mingw_armv7'
                 return 'mingw_i686_clang'
             if 'amd64' in sys.version.lower():
                 return 'mingw_x86_64'

--- a/PC/_testconsole.c
+++ b/PC/_testconsole.c
@@ -6,7 +6,7 @@
 
 #ifdef MS_WINDOWS
 
-#include "..\modules\_io\_iomodule.h"
+#include "../Modules/_io/_iomodule.h"
 
 #define WIN32_LEAN_AND_MEAN
 #include <windows.h>
@@ -104,7 +104,7 @@ _testconsole_read_output_impl(PyObject *module, PyObject *file)
     Py_RETURN_NONE;
 }
 
-#include "clinic\_testconsole.c.h"
+#include "clinic/_testconsole.c.h"
 
 PyMethodDef testconsole_methods[] = {
     _TESTCONSOLE_WRITE_INPUT_METHODDEF

--- a/Python/getcompiler.c
+++ b/Python/getcompiler.c
@@ -20,6 +20,8 @@
 #define ARCH_SUFFIX " 64 bit (AMD64)"
 #elif defined(__aarch64__)
 #define ARCH_SUFFIX " 64 bit (ARM64)"
+#elif defined(__arm__)
+#define ARCH_SUFFIX " 32 bit (ARM)"
 #else
 #define ARCH_SUFFIX " 32 bit"
 #endif

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -83,10 +83,11 @@ Py_GetAltSepA(const char *name)
 void
 Py_NormalizeSepsA(char *name)
 {
+    assert(name != NULL);
     char sep = Py_GetSepA(name);
     char altsep = Py_GetAltSepA(name);
     char* seps;
-    if (strlen(name) > 1 && name[1] == ':') {
+    if (name[0] != '\0' && name[1] == ':') {
         name[0] = toupper(name[0]);
     }
     seps = strchr(name, altsep);
@@ -135,10 +136,11 @@ Py_GetAltSepW(const wchar_t *name)
 void
 Py_NormalizeSepsW(wchar_t *name)
 {
+    assert(name != NULL);
     wchar_t sep = Py_GetSepW(name);
     wchar_t altsep = Py_GetAltSepW(name);
     wchar_t* seps;
-    if (wcslen(name) > 1 && name[1] == L':') {
+    if (name[0] != L'\0' && name[1] == L':') {
         name[0] = towupper(name[0]);
     }
     seps = wcschr(name, altsep);

--- a/Python/pathconfig.c
+++ b/Python/pathconfig.c
@@ -20,6 +20,30 @@ extern "C" {
 #include <windows.h>
 #endif
 
+static int
+Py_StartsWithA(const char * str, const char * prefix)
+{
+    while(*prefix)
+    {
+        if(*prefix++ != *str++)
+            return 0;
+    }
+
+    return 1;
+}
+
+static int
+Py_StartsWithW(const wchar_t * str, const wchar_t * prefix)
+{
+    while(*prefix)
+    {
+        if(*prefix++ != *str++)
+            return 0;
+    }
+
+    return 1;
+}
+
 char
 Py_GetSepA(const char *name)
 {
@@ -30,7 +54,7 @@ Py_GetSepA(const char *name)
      * The "\\?\" prefix .. indicate that the path should be passed to the system with minimal
      * modification, which means that you cannot use forward slashes to represent path separators
      */
-    if (name != NULL && memcmp(name, "\\\\?\\", sizeof("\\\\?\\") - sizeof(char)) == 0)
+    if (name != NULL && Py_StartsWithA(name, "\\\\?\\") != 0)
     {
         return '\\';
     }
@@ -82,7 +106,7 @@ Py_GetSepW(const wchar_t *name)
      * The "\\?\" prefix .. indicate that the path should be passed to the system with minimal
      * modification, which means that you cannot use forward slashes to represent path separators
      */
-    if (name != NULL && memcmp(name, L"\\\\?\\", sizeof(L"\\\\?\\") - sizeof(wchar_t)) == 0)
+    if (name != NULL && Py_StartsWithW(name, L"\\\\?\\") != 0)
     {
         return L'\\';
     }

--- a/configure.ac
+++ b/configure.ac
@@ -3379,7 +3379,7 @@ else
 fi
 
 if test "$with_system_ffi" = "yes" && test -n "$PKG_CONFIG"; then
-    LIBFFI_INCLUDEDIR="`"$PKG_CONFIG" libffi --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ *$//'`"
+    LIBFFI_INCLUDEDIR="`"$PKG_CONFIG" libffi --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ .*$//'`"
 else
     LIBFFI_INCLUDEDIR=""
 fi
@@ -5631,7 +5631,7 @@ then
 fi
 
 if test -n "$PKG_CONFIG"; then
-    NCURSESW_INCLUDEDIR="`"$PKG_CONFIG" ncursesw --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ *$//'`"
+    NCURSESW_INCLUDEDIR="`"$PKG_CONFIG" ncursesw --cflags-only-I 2>/dev/null | sed -e 's/^-I//;s/ .*$//'`"
 else
     NCURSESW_INCLUDEDIR=""
 fi
@@ -5639,9 +5639,7 @@ AC_SUBST(NCURSESW_INCLUDEDIR)
 
 # first curses header check
 ac_save_cppflags="$CPPFLAGS"
-if test "$cross_compiling" = no; then
-  CPPFLAGS="$CPPFLAGS -I$NCURSESW_INCLUDEDIR"
-fi
+CPPFLAGS="$CPPFLAGS -I$NCURSESW_INCLUDEDIR"
 
 AC_CHECK_HEADERS(curses.h ncurses.h)
 

--- a/configure.ac
+++ b/configure.ac
@@ -5195,6 +5195,9 @@ case $host_os in
   aarch64-*-mingw*)
     PYD_PLATFORM_TAG+="mingw_aarch64"
     ;;
+  armv7-*-mingw*)
+    PYD_PLATFORM_TAG+="mingw_armv7"
+    ;;
   esac
   AC_MSG_RESULT($PYD_PLATFORM_TAG)
 esac

--- a/setup.py
+++ b/setup.py
@@ -786,14 +786,25 @@ class PyBuildExt(build_ext):
                         elif line.startswith("End of search list"):
                             in_incdirs = False
                         elif (is_gcc or is_clang) and line.startswith("LIBRARY_PATH"):
-                            for d in line.strip().split("=")[1].split(":"):
+                            for d in line.strip().split("=")[1].split(os.pathsep):
                                 d = os.path.normpath(d)
-                                if '/gcc/' not in d:
+                                if '/gcc/' not in d and '/clang/' not in d:
                                     add_dir_to_list(self.compiler.library_dirs,
                                                     d)
                         elif (is_gcc or is_clang) and in_incdirs and '/gcc/' not in line and '/clang/' not in line:
                             add_dir_to_list(self.compiler.include_dirs,
                                             line.strip())
+            if is_clang:
+                ret = run_command('%s -print-search-dirs >%s' % (cc, tmpfile))
+                if ret == 0:
+                    with open(tmpfile) as fp:
+                        for line in fp.readlines():
+                            if line.startswith("libraries:"):
+                                for d in line.strip().split("=")[1].split(os.pathsep):
+                                    d = os.path.normpath(d)
+                                    if '/gcc/' not in d and '/clang/' not in d:
+                                        add_dir_to_list(self.compiler.library_dirs,
+                                                        d)
         finally:
             os.unlink(tmpfile)
 

--- a/setup.py
+++ b/setup.py
@@ -1202,8 +1202,7 @@ class PyBuildExt(build_ext):
         panel_library = 'panel'
         if curses_library == 'ncursesw':
             curses_defines.append(('HAVE_NCURSESW', '1'))
-            if not CROSS_COMPILING:
-                curses_includes.append(sysconfig.get_config_var("NCURSESW_INCLUDEDIR"))
+            curses_includes.append(sysconfig.get_config_var("NCURSESW_INCLUDEDIR"))
             # Bug 1464056: If _curses.so links with ncursesw,
             # _curses_panel.so must link with panelw.
             panel_library = 'panelw'


### PR DESCRIPTION
I looked at the git log for mingw-v3.10.0 and mingw-v3.9.7 and cherry-picked each commit from mingw-v3.9.7 that was above the last commit message shared with mingw-v3.10.0.

There was probably an easier way to do this (with rebase?) but I wanted to do each commit individually in case of conflicts (which amazingly there were none).  The only manual edit I made was to change the setup-python action to request 3.10 now instead of 3.9.

Some of these commits could probably reasonably be squashed.  I don't know if it's worth doing this here, or just waiting until rebasing to 3.10.2 and then having the option to squash with other commits that already exist on the 3.10.0 branch.