### PR TITLE
add CI test of build with llvm-mingw

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -153,7 +153,7 @@ jobs:
           name: build-${{ matrix.msystem }}
           path: _build/python.tar.gz
 
-  cross:
+  cross-gcc-x86_64:
     runs-on: ubuntu-latest
     container:
       image: archlinux:base-devel
@@ -192,18 +192,93 @@ jobs:
       - name: Upload
         uses: actions/upload-artifact@v2
         with:
-          name: build-cross
+          name: build-cross-gcc-x86_64
           path: install.zip
 
-  cross-test:
-    needs: [cross]
+  cross-gcc-x86_64-test:
+    needs: [cross-gcc-x86_64]
     runs-on: windows-latest
     steps:
       - uses: actions/download-artifact@v2
         with:
-          name: build-cross
+          name: build-cross-gcc-x86_64
 
       - name: 'Run tests'
         run: |
           7z x install.zip
           ./_build/install/usr/local/bin/python3.exe -c "import sysconfig, pprint; pprint.pprint(sysconfig.get_config_vars())"
+
+
+  cross-llvm-mingw:
+    runs-on: ubuntu-18.04
+    container:
+      image: mstorsjo/llvm-mingw:latest
+    strategy:
+      matrix:
+        arch: ['x86_64', 'i686', 'aarch64', 'armv7']
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install deps
+        run: |
+          apt-get update -qq
+          apt-get install -qqy autoconf-archive
+
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.10'
+
+      - name: Check Python Version
+        run: |
+          which python
+          python --version
+
+      - name: Build
+        run: |
+          autoreconf -vfi
+
+          mkdir _build && cd _build
+
+          export CC=${{ matrix.arch }}-w64-mingw32-clang
+          export CXX=${CC}++
+          ../configure \
+            --host=${{ matrix.arch }}-w64-mingw32 \
+            --build=x86_64-pc-linux-gnu \
+            --enable-shared \
+            --with-system-expat \
+            --with-system-ffi \
+            --with-system-libmpdec \
+            --without-ensurepip \
+            --without-c-locale-coercion \
+            --enable-loadable-sqlite-extensions
+
+          make -j8
+
+          make install DESTDIR="$(pwd)/install"
+
+      - name: 'Zip files'
+        run: |
+          zip -r install.zip _build/install
+
+      - name: Upload
+        uses: actions/upload-artifact@v2
+        with:
+          name: build-cross-llvm-mingw-${{ matrix.arch }}
+          path: install.zip
+
+  cross-llvm-mingw-test:
+    needs: [cross-llvm-mingw]
+    runs-on: windows-latest
+    strategy:
+      matrix:
+        arch: ['x86_64', 'i686']
+    steps:
+      - uses: actions/download-artifact@v2
+        with:
+          name: build-cross-llvm-mingw-${{ matrix.arch }}
+
+      - name: 'Run tests'
+        run: |
+          7z x install.zip
+          ./_build/install/usr/local/bin/python3.exe -c "import sysconfig, pprint; pprint.pprint(sysconfig.get_config_vars())"
+
+


### PR DESCRIPTION
@mstorsjo's llvm-mingw project also builds this repo (in addition to just MSYS2) so it may be nice to give it some coverage here too, at least for any major/obvious breakage.  This is also probably the only way we're going to get any coverage whatsoever of armv7, as I don't think anybody has the appetite to add that environment to MSYS2.