### PR TITLE
define PY3_DLLNAME properly

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -3961,7 +3961,7 @@ then
 	*-*-mingw*)
 	DYNLOADFILE="dynload_win.o"
 	extra_machdep_objs="$extra_machdep_objs PC/dl_nt.o"
-	CFLAGS_NODIST="$CFLAGS_NODIST -DMS_DLL_ID='\"$VERSION\"' -DPY3_DLLNAME='\"libpython3.dll\"'"
+	CFLAGS_NODIST="$CFLAGS_NODIST -DMS_DLL_ID='\"$VERSION\"' -DPY3_DLLNAME='L\"$DLLLIBRARY\"'"
 	;;
 	esac
 fi


### PR DESCRIPTION
In addition to including the 'short' version (3.10), it should be a wide character string.  Fixes #73 