### PR TITLE
mingw_smoketests: fix _UCRT condition

### DIFF
--- a/mingw_smoketests.py
+++ b/mingw_smoketests.py
@@ -34,7 +34,7 @@ if "MSYSTEM" in os.environ:
 else:
     SEP = "\\"
 
-_UCRT = "clang" in sysconfig.get_platform() or "ucrt" in sysconfig.get_platform()
+_UCRT = sysconfig.get_platform() not in ('mingw_x86_64', 'mingw_i686')
 
 
 class Tests(unittest.TestCase):


### PR DESCRIPTION
The prior detection missed ARM (32 and 64) being UCRT.  Since there are fewer non-UCRT platforms, list those two instead of trying to extend the list of UCRT.

Fixes #72