### PR TITLE
Use CC instead of cc

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -722,7 +722,7 @@ class PyBuildExt(build_ext):
                             add_dir_to_list(self.compiler.include_dirs,
                                             line.strip())
             if is_clang:
-                ret = run_command('%s -print-search-dirs >%s' % (cc, tmpfile))
+                ret = run_command('%s -print-search-dirs >%s' % (CC, tmpfile))
                 if ret == 0:
                     with open(tmpfile) as fp:
                         for line in fp.readlines():


### PR DESCRIPTION
`cc` is not defined within this function, so this line will fail on cross Clang build