### PR TITLE
configure: Include a header in the check for _beginthread

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -2242,7 +2242,7 @@ AC_MSG_RESULT([$with_nt_threads])
 if test $with_nt_threads = yes ; then
 AC_MSG_CHECKING([whether linking with nt-threads work])
 AC_LINK_IFELSE([
-    AC_LANG_PROGRAM([[]],[[_beginthread(0, 0, 0);]])
+    AC_LANG_PROGRAM([[#include <process.h>]],[[_beginthread(0, 0, 0);]])
   ],
   [AC_MSG_RESULT([yes])],
   [AC_MSG_ERROR([failed to link with nt-threads])])


### PR DESCRIPTION
Previously, the test tried compiling a call to the `_beginthread` function without either declaring the function (and its parameters) or including the corresponding header.

Since Clang 15 (which still is under development, so this may still change before it's released) [1], implicit function declarations are a hard error by default, when building code in C99 mode (or newer).

[1] https://github.com/llvm/llvm-project/commit/7d644e1215b376ec5e915df9ea2eeb56e2d94626
