### PR TITLE
configure.ac: Default to --without-c-locale-coercion on Windows

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -75,7 +75,6 @@ jobs:
             --with-system-ffi \
             --with-system-libmpdec \
             --without-ensurepip \
-            --without-c-locale-coercion \
             --enable-loadable-sqlite-extensions \
             --with-tzpath=${MINGW_PREFIX}/share/zoneinfo \
             --enable-optimizations
@@ -187,7 +186,6 @@ jobs:
             --with-system-ffi \
             --with-system-libmpdec \
             --without-ensurepip \
-            --without-c-locale-coercion \
             --enable-loadable-sqlite-extensions
 
           make -j8

--- a/configure.ac
+++ b/configure.ac
@@ -3884,11 +3884,14 @@ AC_MSG_RESULT($with_pymalloc)
 AC_MSG_CHECKING(for --with-c-locale-coercion)
 AC_ARG_WITH(c-locale-coercion,
             AS_HELP_STRING([--with-c-locale-coercion],
-              [enable C locale coercion to a UTF-8 based locale (default is yes)]))
+              [enable C locale coercion to a UTF-8 based locale (default is yes on Unix, no on Windows)]))
 
 if test -z "$with_c_locale_coercion"
 then
-    with_c_locale_coercion="yes"
+    case $host in
+      *-*-mingw*) with_c_locale_coercion="no";;
+      *) with_c_locale_coercion="yes";;
+    esac
 fi
 if test "$with_c_locale_coercion" != "no"
 then


### PR DESCRIPTION
--with-c-locale-coercion otherwise defaults to yes and enables code
that isn't compatible on Windows, mainly because the feature is Unix related.

Default to "no" on Windows instead.

Fixes #36
