### PR TITLE
Revert "distutils: msys convert_path fix and root hack"

### DIFF
--- a/Lib/distutils/command/install.py
+++ b/Lib/distutils/command/install.py
@@ -342,8 +342,7 @@ class install(Command):
 
         # Convert directories from Unix /-separated syntax to the local
         # convention.
-        self.convert_paths('base', 'platbase',
-                           'lib', 'purelib', 'platlib',
+        self.convert_paths('lib', 'purelib', 'platlib',
                            'scripts', 'data', 'headers',
                            'userbase', 'usersite')
 

--- a/Lib/distutils/util.py
+++ b/Lib/distutils/util.py
@@ -145,13 +145,6 @@ def convert_path (pathname):
         paths.remove('.')
     if not paths:
         return os.curdir
-    # On Windows, if paths is ['C:','folder','subfolder'] then
-    # os.path.join(*paths) will return 'C:folder\subfolder' which
-    # is thus relative to the CWD on that drive. So we work around
-    # this by adding a \ to path[0]
-    if (len(paths) > 0 and paths[0].endswith(':') and
-        sys.platform == "win32" and sys.version.find("GCC") >= 0):
-        paths[0] += '\\'
     return os.path.join(*paths)
 
 # convert_path ()
@@ -162,10 +155,6 @@ def change_root (new_root, pathname):
     relative, this is equivalent to "os.path.join(new_root,pathname)".
     Otherwise, it requires making 'pathname' relative and then joining the
     two, which is tricky on DOS/Windows and Mac OS.
-
-    If on Windows or OS/2 and both new_root and pathname are on different
-    drives, raises DistutilsChangeRootError as this is nonsensical,
-    otherwise use drive which can be in either of new_root or pathname.
     """
     if os.name == 'posix':
         if not os.path.isabs(pathname):
@@ -175,20 +164,9 @@ def change_root (new_root, pathname):
 
     elif os.name == 'nt':
         (drive, path) = os.path.splitdrive(pathname)
-        if path[0] == os.sep:
+        if path[0] == '\\':
             path = path[1:]
-        (drive_r, path_r) = os.path.splitdrive(new_root)
-        if path_r and path_r[0] == os.sep:
-            path_r = path_r[1:]
-        drive_used = ''
-        if len(drive) == 2 and len(drive_r) == 2 and drive != drive_r:
-            raise DistutilsChangeRootError("root and pathname not on same drive (%s, %s)"
-                   % (drive_r,drive))
-        elif len(drive_r) == 2:
-            drive_used = drive_r+os.sep
-        elif len(drive) == 2:
-            drive_used = drive+os.sep
-        return os.path.join(drive_used+path_r, path)
+        return os.path.join(new_root, path)
 
     else:
         raise DistutilsPlatformError("nothing known about platform '%s'" % os.name)


### PR DESCRIPTION
This reverts commit 6069c12c833233f2226421f2452a0585db0539ad.

1) convert_paths on base/platbase shouldn't be needed in theory since
   the paths are absolute at that point
2) The case join() tries to fix is expected behaviour, so seems to work around
   broken input from somewhere else, but not clear what/why
3) The change_root() part doesn't make much sense, it is only used for installing
   and having this on different drives seems fine to me. And the raised exception
   doesn't exist, see https://github.com/msys2-contrib/cpython-mingw/issues/38

To summarize, all those changes are somewhat questionable, and we should try to
figure out if they are really needed by reverting them.