### PR TITLE
WIP: Fix tests 3.10 branch

### DIFF
--- a/Lib/distutils/command/build_ext.py
+++ b/Lib/distutils/command/build_ext.py
@@ -227,7 +227,7 @@ class build_ext(Command):
                                                       config_dir_name))
             else:
                 # building python standard extensions
-                self.library_dirs.append('.')
+                self.library_dirs.append(sysconfig.project_base)
 
         # For building extensions with a shared Python library,
         # Python's library directory must be appended to library_dirs
@@ -238,7 +238,7 @@ class build_ext(Command):
                 self.library_dirs.append(sysconfig.get_config_var('LIBDIR'))
             else:
                 # building python standard extensions
-                self.library_dirs.append('.')
+                self.library_dirs.append(sysconfig.project_base)
 
         # The argument parsing will result in self.define being a string, but
         # it has to be a list of 2-tuples.  All the preprocessor symbols

--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -25,6 +25,23 @@ def get_platform():
             'x64' : 'win-amd64',
             'arm' : 'win-arm32',
         }
+    if os.name == 'nt':
+        if 'gcc' in sys.version.lower():
+            if 'ucrt' in sys.version.lower():
+                if 'amd64' in sys.version.lower():
+                    return 'mingw_x86_64_ucrt'
+                return 'mingw_i686_ucrt'
+            if 'clang' in sys.version.lower():
+                if 'amd64' in sys.version.lower():
+                    return 'mingw_x86_64_clang'
+                if 'arm64' in sys.version.lower():
+                    return 'mingw_aarch64'
+                if 'arm' in sys.version.lower():
+                    return 'mingw_armv7'
+                return 'mingw_i686_clang'
+            if 'amd64' in sys.version.lower():
+                return 'mingw_x86_64'
+            return 'mingw_i686'
     if ('VSCMD_ARG_TGT_ARCH' in os.environ and
         os.environ['VSCMD_ARG_TGT_ARCH'] in TARGET_TO_PLAT):
         return TARGET_TO_PLAT[os.environ['VSCMD_ARG_TGT_ARCH']]

--- a/mingw_ignorefile.txt
+++ b/mingw_ignorefile.txt
@@ -29,6 +29,10 @@ test.test_strptime.TimeRETests.test_compile
 test.test_tools.test_i18n.Test_pygettext.test_POT_Creation_Date
 test.test_venv.BasicTest.*
 test.test_venv.EnsurePipTest.*
+test.test_sysconfig.TestSysConfig.test_user_similar
+test.test_tcl.TclTest.testLoadWithUNC
 # flaky
 test.test__xxsubinterpreters.*
 test.test_asyncio.test_subprocess.SubprocessProactorTests.test_stdin_broken_pipe
+test.test_asynchat.TestAsynchat.test_line_terminator2
+


### PR DESCRIPTION
notes: https://gist.github.com/naveen521kk/9e2a0ae3fcc18f615394d774a9948878
fixes https://github.com/msys2-contrib/cpython-mingw/issues/80
with this, ig we can make 3.10 the default python provided in msys2