### PR TITLE
Revert "Skip building c-extensions if python is running in build tree"

### DIFF
--- a/mingw_smoketests.py
+++ b/mingw_smoketests.py
@@ -233,13 +233,6 @@ class Tests(unittest.TestCase):
         import textwrap
         from pathlib import Path
 
-        if sysconfig.is_python_build():
-            # we are running this test without installing and is known
-            # to cause errors with building c-extensions
-            # so we are skipping this test
-            raise unittest.SkipTest("Skipping test as building c-extension isn't supported \
-                without installing python")
-
         with tempfile.TemporaryDirectory() as tmppro:
             subprocess.check_call([sys.executable, "-m", "ensurepip", "--user"])
             with Path(tmppro, "setup.py").open("w") as f:


### PR DESCRIPTION
This reverts commit 77c1c9340da9fe43e744cc4e9f42ec98c6d278f0.

I think e31e5e01d7e also fixed this case.