### PR TITLE
configure: require autoreconf to be run first

### DIFF
--- a/configure
+++ b/configure
@@ -14,6 +14,9 @@
 ## M4sh Initialization. ##
 ## -------------------- ##
 
+echo "error: configure file out of date, please run 'autoreconf -vfi' first" >&2
+exit 1
+
 # Be more Bourne compatible
 DUALCASE=1; export DUALCASE # for MKS sh
 if test -n "${ZSH_VERSION+set}" && (emulate sh) >/dev/null 2>&1; then :


### PR DESCRIPTION
We currently patch configure.ac which requires users to regen configure to get those changes. Since that isn't clear make configure error out by default with a helpful message.
