### PR TITLE
Search DLLs only on paths added using `add_dll_directory()`.

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -130,16 +130,16 @@ jobs:
           cp "${pkgdir}${MINGW_PREFIX}"/bin/idle3 "${pkgdir}${MINGW_PREFIX}"/bin/idle
           cp "${pkgdir}${MINGW_PREFIX}"/bin/pydoc3 "${pkgdir}${MINGW_PREFIX}"/bin/pydoc
 
+          # copy to /
+          cp -rf "${pkgdir}"/* /
+
       - name: Run Smoke Test (installed)
         shell: msys2 {0}
         run: |
           export SETUPTOOLS_USE_DISTUTILS=stdlib
-          export PYTHONTZPATH="${MINGW_PREFIX}/share/zoneinfo"
           SMOKETESTS="$(pwd)/mingw_smoketests.py"
-          cd _build
-          cd python_pkgdir/${MINGW_PREFIX}/bin
-          ./python.exe "$SMOKETESTS"
-          MSYSTEM= ./python.exe "$SMOKETESTS"
+          ${MINGW_PREFIX}/bin/python.exe "$SMOKETESTS"
+          MSYSTEM= ${MINGW_PREFIX}/bin/python.exe "$SMOKETESTS"
 
       - name: Compress
         if: always()

--- a/Lib/test/__main__.py
+++ b/Lib/test/__main__.py
@@ -1,2 +1,10 @@
+import os
+import sys
+
 from test.libregrtest import main
+
+if sys.platform == "win32":
+    # Enable DLL loading from PATH.
+    os.environ["PYTHONLEGACYWINDOWSDLLLOADING"] = "1"
+
 main()

--- a/Python/dynload_win.c
+++ b/Python/dynload_win.c
@@ -4,6 +4,7 @@
 #include "Python.h"
 #include "pycore_fileutils.h"     // _Py_add_relfile()
 #include "pycore_pystate.h"       // _PyInterpreterState_GET()
+#include "pycore_initconfig.h"
 
 #ifdef HAVE_DIRECT_H
 #include <direct.h>
@@ -223,6 +224,18 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
     dl_funcptr p;
     char funcname[258], *import_python;
 
+    int use_legacy = 0;
+    DWORD load_library_flags = 0;
+
+    _Py_get_env_flag(1, &use_legacy, "PYTHONLEGACYWINDOWSDLLLOADING");
+
+    if (use_legacy) {
+        load_library_flags = LOAD_WITH_ALTERED_SEARCH_PATH;
+    } else {
+        load_library_flags = LOAD_LIBRARY_SEARCH_DEFAULT_DIRS |
+                              LOAD_LIBRARY_SEARCH_DLL_LOAD_DIR;
+    }
+
 #ifdef _MSC_VER
     _Py_CheckPython3(); 
 #endif
@@ -249,8 +262,7 @@ dl_funcptr _PyImport_FindSharedFuncptrWindows(const char *prefix,
            AddDllDirectory function. We add SEARCH_DLL_LOAD_DIR to
            ensure DLLs adjacent to the PYD are preferred. */
         Py_BEGIN_ALLOW_THREADS
-        hDLL = LoadLibraryExW(wpathname, NULL,
-                              LOAD_WITH_ALTERED_SEARCH_PATH);
+        hDLL = LoadLibraryExW(wpathname, NULL, load_library_flags);
         Py_END_ALLOW_THREADS
 #if !USE_UNICODE_WCHAR_CACHE
         PyMem_Free(wpathname);

--- a/mingw_smoketests.py
+++ b/mingw_smoketests.py
@@ -34,6 +34,9 @@ if os.environ.get("MSYSTEM", ""):
 else:
     SEP = "\\"
 
+if sysconfig.is_python_build():
+    os.environ["PYTHONLEGACYWINDOWSDLLLOADING"] = "1"
+
 _UCRT = sysconfig.get_platform() not in ('mingw_x86_64', 'mingw_i686')
 
 

--- a/setup.py
+++ b/setup.py
@@ -88,6 +88,10 @@ if sys.platform == "win32" and os.environ.get("MSYSTEM", ""):
         return os_system(command_in_sh)
     os.system = msys_system
 
+    # set PYTHONLEGACYWINDOWSDLLLOADING to 1 to load DLLs from PATH
+    # This is needed while building core extensions of Python
+    os.environ["PYTHONLEGACYWINDOWSDLLLOADING"] = "1"
+
 CROSS_COMPILING = ("_PYTHON_HOST_PLATFORM" in os.environ)
 HOST_PLATFORM = get_platform()
 MS_WINDOWS = (HOST_PLATFORM == 'win32' or HOST_PLATFORM == 'mingw')


### PR DESCRIPTION
This is the default behavior on upstream Python. We previously reverted this behavior because it broke some use cases.

The old behavior can be restored by setting the environment variable PYTHONLEGACYWINDOWSDLLLOADING to 1.

Fixes https://github.com/msys2-contrib/cpython-mingw/issues/48
Also fixes https://github.com/msys2-contrib/cpython-mingw/issues/141
