### PR TITLE
fixup! sysconfig: make _sysconfigdata.py relocatable

### DIFF
--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -542,7 +542,7 @@ def _generate_posix_vars():
 
         for key in keys_to_replace:
             value = build_time_vars[key]
-            build_time_vars[key] = value.replace(prefix, sys.prefix)
+            build_time_vars[key] = value.replace(prefix, sys.base_prefix)
     """
 
     with open(destfile, 'w', encoding='utf8') as f:


### PR DESCRIPTION
Use `sys.base_prefix` for sysconfig relocation
Previously, we were using `sys.prefix` for relocation, which is not right as it may change for virtualenvs. `sys.base_prefix` is the right variable to use.
