### PR TITLE
Makefile: Add a dependency on $(LDLIBRARY) for the sharedmods target

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -778,7 +778,7 @@ $(srcdir)/Modules/_blake2/blake2s_impl.c: $(srcdir)/Modules/_blake2/blake2b_impl
 # -s, --silent or --quiet is always the first char.
 # Under BSD make, MAKEFLAGS might be " -s -v x=y".
 # Ignore macros passed by GNU make, passed after --
-sharedmods: $(PYTHON_FOR_BUILD_DEPS) pybuilddir.txt @LIBMPDEC_INTERNAL@ @LIBEXPAT_INTERNAL@
+sharedmods: $(PYTHON_FOR_BUILD_DEPS) pybuilddir.txt $(LDLIBRARY) @LIBMPDEC_INTERNAL@ @LIBEXPAT_INTERNAL@
 	@case "`echo X $$MAKEFLAGS | sed 's/^X //;s/ -- .*//'`" in \
 	    *\ -s*|s*) quiet="-q";; \
 	    *) quiet="";; \


### PR DESCRIPTION
When building shared modules (`*.pyd`) for MinGW, they link against the import library for the main python (e.g. `-lpython3.11`). When linking shared modules on Linux, this doesn't happen, but those shared libraries are linked with undefined references which then are fulfilled by the host process when they are loaded.

Add a dependency to make sure that `$(LDLIBRARY)`, e.g. `libpython$(LDVERSION).dll.a`, exists before starting to build the shared modules.

Previously, if `libpython$(LDVERSION).dll.a` didn't exist when the shared modules were linked, some of them failed to link, but this wasn't reported as an error in the build, and a later invocation of `setup.py` would retry building them, which then would succeed. E.g. there was a seemingly benign race condition in the build.

However, in some rare cases, the race condition no longer was benign. The build also produces a corresponding static library, `$(LIBRARY)`, e.g. `libpython$(VERSION)$(ABIFLAGS).a` - which in the end would be named similarly, `libpython3.11.a`, when `$(LDLIBRARY)` would be `libpython3.11.dll.a`.

If the static library exists but the import library doesn't, then most modules would still fail to link, but a few ones wouldn't (`select`, `_multiprocessing`, `_overlapped` and `_socket`). The ones that did succeed linking with the static library would crash at runtime though.

By making sure that the right, intended library to fulfill the linker parameter `-lpython3.11` exists before building the shared modules, we avoid the whole race condition that in some rare cases could produce a Python build that crashes at runtime.

For Linux targets, this extra dependency is unnecessary, but should not cause other problems (`$(LDLIBRARY)` is set to the same as `$(LIBRARY)` if not building any shared library).

This fixes MSYS2 cpython-mingw issue #162.