### PR TITLE
`sysconfig.get_platform()`: use consistent naming

### DIFF
--- a/Lib/site.py
+++ b/Lib/site.py
@@ -314,21 +314,27 @@ def _getuserbase():
 def _get_platform():
     if os.name == 'nt':
         if 'gcc' in sys.version.lower():
-            if 'ucrt' in sys.version.lower():
-                if 'amd64' in sys.version.lower():
-                    return 'mingw_x86_64_ucrt'
-                return 'mingw_i686_ucrt'
-            if 'clang' in sys.version.lower():
-                if 'amd64' in sys.version.lower():
-                    return 'mingw_x86_64_clang'
-                if 'arm64' in sys.version.lower():
-                    return 'mingw_aarch64'
-                if 'arm' in sys.version.lower():
-                    return 'mingw_armv7'
-                return 'mingw_i686_clang'
+            platform = 'mingw'
             if 'amd64' in sys.version.lower():
-                return 'mingw_x86_64'
-            return 'mingw_i686'
+                platform += '_x86_64'
+            elif 'arm64' in sys.version.lower():
+                platform += '_aarch64'
+            elif 'arm' in sys.version.lower():
+                platform += '_armv7'
+            else:
+                platform += '_i686'
+
+            if 'ucrt' in sys.version.lower():
+                platform += '_ucrt'
+            else:
+                platform += "_msvcrt"
+
+            if 'clang' in sys.version.lower():
+                platform += "_llvm"
+            else:
+                platform += "_gnu"
+            
+            return platform
     return sys.platform
 
 # Same to sysconfig.get_path('purelib', os.name+'_user')

--- a/Lib/sysconfig.py
+++ b/Lib/sysconfig.py
@@ -800,21 +800,27 @@ def get_platform():
     """
     if os.name == 'nt':
         if 'gcc' in sys.version.lower():
-            if 'ucrt' in sys.version.lower():
-                if 'amd64' in sys.version.lower():
-                    return 'mingw_x86_64_ucrt'
-                return 'mingw_i686_ucrt'
-            if 'clang' in sys.version.lower():
-                if 'amd64' in sys.version.lower():
-                    return 'mingw_x86_64_clang'
-                if 'arm64' in sys.version.lower():
-                    return 'mingw_aarch64'
-                if 'arm' in sys.version.lower():
-                    return 'mingw_armv7'
-                return 'mingw_i686_clang'
+            platform = 'mingw'
             if 'amd64' in sys.version.lower():
-                return 'mingw_x86_64'
-            return 'mingw_i686'
+                platform += '_x86_64'
+            elif 'arm64' in sys.version.lower():
+                platform += '_aarch64'
+            elif 'arm' in sys.version.lower():
+                platform += '_armv7'
+            else:
+                platform += '_i686'
+
+            if 'ucrt' in sys.version.lower():
+                platform += '_ucrt'
+            else:
+                platform += "_msvcrt"
+
+            if 'clang' in sys.version.lower():
+                platform += "_llvm"
+            else:
+                platform += "_gnu"
+            
+            return platform
         if 'amd64' in sys.version.lower():
             return 'win-amd64'
         if '(arm)' in sys.version.lower():

--- a/Lib/test/test_importlib/test_windows.py
+++ b/Lib/test/test_importlib/test_windows.py
@@ -25,22 +25,28 @@ def get_platform():
             'arm' : 'win-arm32',
         }
     if os.name == 'nt':
-        if 'gcc' in sys.version.lower():
-            if 'ucrt' in sys.version.lower():
-                if 'amd64' in sys.version.lower():
-                    return 'mingw_x86_64_ucrt'
-                return 'mingw_i686_ucrt'
-            if 'clang' in sys.version.lower():
-                if 'amd64' in sys.version.lower():
-                    return 'mingw_x86_64_clang'
-                if 'arm64' in sys.version.lower():
-                    return 'mingw_aarch64'
-                if 'arm' in sys.version.lower():
-                    return 'mingw_armv7'
-                return 'mingw_i686_clang'
-            if 'amd64' in sys.version.lower():
-                return 'mingw_x86_64'
-            return 'mingw_i686'
+        if "gcc" in sys.version.lower():
+            platform = "mingw"
+            if "amd64" in sys.version.lower():
+                platform += "_x86_64"
+            elif "arm64" in sys.version.lower():
+                platform += "_aarch64"
+            elif "arm" in sys.version.lower():
+                platform += "_armv7"
+            else:
+                platform += "_i686"
+
+            if "ucrt" in sys.version.lower():
+                platform += "_ucrt"
+            else:
+                platform += "_msvcrt"
+
+            if "clang" in sys.version.lower():
+                platform += "_llvm"
+            else:
+                platform += "_gnu"
+
+            return platform
     if ('VSCMD_ARG_TGT_ARCH' in os.environ and
         os.environ['VSCMD_ARG_TGT_ARCH'] in TARGET_TO_PLAT):
         return TARGET_TO_PLAT[os.environ['VSCMD_ARG_TGT_ARCH']]

--- a/Python/getcompiler.c
+++ b/Python/getcompiler.c
@@ -32,8 +32,13 @@
 #if defined(__clang__)
 #define str(x) #x
 #define xstr(x) str(x)
+#if defined(_UCRT)
+#define COMPILER COMP_SEP "[GCC UCRT Clang " xstr(__clang_major__) "." \
+        xstr(__clang_minor__) "." xstr(__clang_patchlevel__) ARCH_SUFFIX "]"
+#else
 #define COMPILER COMP_SEP "[GCC Clang " xstr(__clang_major__) "." \
         xstr(__clang_minor__) "." xstr(__clang_patchlevel__) ARCH_SUFFIX "]"
+#endif
 #else
 #if defined(_UCRT)
 #define COMPILER COMP_SEP "[GCC UCRT " __VERSION__ ARCH_SUFFIX "]"

--- a/configure.ac
+++ b/configure.ac
@@ -6353,7 +6353,7 @@ case $host_os in
   if test $linking_to_ucrt = no; then
     PYD_PLATFORM_TAG+="_msvcrt"
   else
-    PYD_PLATFORM_TAG += "_ucrt"
+    PYD_PLATFORM_TAG+="_ucrt"
   fi
   if test -n "${cc_is_clang}"; then
     # it is CLANG32

--- a/configure.ac
+++ b/configure.ac
@@ -6311,16 +6311,12 @@ AC_C_BIGENDIAN
 
 AC_SUBST(PYD_PLATFORM_TAG)
 # Special case of PYD_PLATFORM_TAG with python build with mingw. 
-# Python can with compiled with clang or gcc and linked
-# to msvcrt or ucrt. To avoid conflicts between them
-# we are selecting the extension as based on the compiler
-# and the runtime they link to
-#   gcc + x86_64 + msvcrt = cp{version number}-x86_64
-#   gcc + i686 + msvcrt = cp{version number}-i686
-#   gcc + x86_64 + ucrt = cp{version number}-x86_64-ucrt
-#   clang + x86_64 + ucrt = cp{version number}-x86_64-clang
-#   clang + i686 + ucrt = cp{version number}-i686-clang
-
+# Python can with different cpu arch and c runtime as well as different
+# toolchain. We follow this`mingw_<cpu_arch>_<c_runtime>_<toolchain>`
+# convention for PYD_PLATFORM_TAG. Where:
+# `cpu_arch` = `x86_64`, `aarch64` or `i686`
+# `c_runtime` = `msvcrt` or `ucrt`
+# `toolchain` = `gnu` or `llvm`
 PYD_PLATFORM_TAG=""
 case $host in
   *-*-mingw*)
@@ -6339,38 +6335,32 @@ esac
 case $host_os in
     mingw*)
   AC_MSG_CHECKING(PYD_PLATFORM_TAG)
+  PYD_PLATFORM_TAG="mingw"
   case $host in
   i686-*-mingw*)
-    if test -n "${cc_is_clang}"; then
-      # it is CLANG32
-      PYD_PLATFORM_TAG="mingw_i686_clang"
-    else
-      if test $linking_to_ucrt = no; then
-        PYD_PLATFORM_TAG="mingw_i686"
-      else
-        PYD_PLATFORM_TAG="mingw_i686_ucrt"
-      fi
-    fi
+    PYD_PLATFORM_TAG+="_i686"
     ;;
   x86_64-*-mingw*)
-    if test -n "${cc_is_clang}"; then
-      # it is CLANG64
-      PYD_PLATFORM_TAG="mingw_x86_64_clang"
-    else
-      if test $linking_to_ucrt = no; then
-        PYD_PLATFORM_TAG="mingw_x86_64"
-      else
-        PYD_PLATFORM_TAG="mingw_x86_64_ucrt"
-      fi
-    fi
+    PYD_PLATFORM_TAG+="_x86_64"
     ;;
   aarch64-*-mingw*)
-    PYD_PLATFORM_TAG+="mingw_aarch64"
+    PYD_PLATFORM_TAG+="_aarch64"
     ;;
   armv7-*-mingw*)
-    PYD_PLATFORM_TAG+="mingw_armv7"
+    PYD_PLATFORM_TAG+="_armv7"
     ;;
   esac
+  if test $linking_to_ucrt = no; then
+    PYD_PLATFORM_TAG+="_msvcrt"
+  else
+    PYD_PLATFORM_TAG += "_ucrt"
+  fi
+  if test -n "${cc_is_clang}"; then
+    # it is CLANG32
+    PYD_PLATFORM_TAG+="_llvm"
+  else
+    PYD_PLATFORM_TAG+="_gnu"
+  fi
   AC_MSG_RESULT($PYD_PLATFORM_TAG)
 esac
 

--- a/mingw_smoketests.py
+++ b/mingw_smoketests.py
@@ -37,7 +37,7 @@ else:
 if sysconfig.is_python_build():
     os.environ["PYTHONLEGACYWINDOWSDLLLOADING"] = "1"
 
-_UCRT = sysconfig.get_platform() not in ('mingw_x86_64', 'mingw_i686')
+_UCRT = 'ucrt' in sysconfig.get_platform()
 
 
 class Tests(unittest.TestCase):


### PR DESCRIPTION
Currently, the platform names are hardcoded in many places and are not named consistently. This commit fixes it by standardizing the names to be returned by `sysconfig.get_platform`. The naming is based on https://github.com/msys2-contrib/cpython-mingw/issues/167#issuecomment-1952215164

Similarly, `EXT_SUFFIX` is also standardized to be consistent with the platform names.
