### PR TITLE
gh-169: venv: install more launchers and batch scripts

### DIFF
--- a/Makefile.pre.in
+++ b/Makefile.pre.in
@@ -2174,7 +2174,7 @@ LIBSUBDIRS=	asyncio \
 		msilib \
 		unittest \
 		urllib \
-		venv venv/scripts venv/scripts/common venv/scripts/posix \
+		venv venv/scripts venv/scripts/common venv/scripts/nt venv/scripts/posix \
 		wsgiref \
 		$(XMLLIBSUBDIRS) \
 		xmlrpc \


### PR DESCRIPTION
Install `venv` launchers `python3.exe`, `python3w.exe`, `python3.12.exe` and the batch scripts. The launchers were installed before, but I simplified the code a lot.

It basically reverts "venv creation fixes".