### PR TITLE
CI: stop testing armv7, no longer possible

### DIFF
--- a/.github/workflows/mingw.yml
+++ b/.github/workflows/mingw.yml
@@ -296,17 +296,13 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        arch: ['x86_64', 'i686', 'aarch64', 'armv7']
+        arch: ['x86_64', 'i686', 'aarch64']
         include:
           - arch: x86_64
             runner: windows-latest
           - arch: i686
             runner: windows-latest
           - arch: aarch64
-            runner: windows-11-arm
-          # we can test this for now, but Windows 11 24H2 dropped support for
-          # arm32
-          - arch: armv7
             runner: windows-11-arm
     steps:
       - uses: actions/download-artifact@v4


### PR DESCRIPTION
The GHA provided runner now runs a newer Windows version which no longer allows running armv7 binaries, so stop testing them there.

Same as with
https://github.com/mingw-w64/mingw-w64/commit/e6535ce604431e885
