### PR TITLE
winreg: patch cleanup

### DIFF
--- a/Modules/Setup.bootstrap.in
+++ b/Modules/Setup.bootstrap.in
@@ -36,6 +36,6 @@ _symtable symtablemodule.c
 @MODULE_PWD_TRUE@pwd pwdmodule.c
 
 # build-in modules for windows platform:
-@USE_WIN32_MODULE@winreg ../PC/winreg.c
+@MODULE_WINREG_TRUE@winreg ../PC/winreg.c
 @MODULE_MSVCRT_TRUE@msvcrt -DPy_BUILD_CORE ../PC/msvcrtmodule.c
 @MODULE__WINAPI_TRUE@_winapi _winapi.c

--- a/PC/winreg.c
+++ b/PC/winreg.c
@@ -19,25 +19,6 @@
 #include "structmember.h"         // PyMemberDef
 #include <windows.h>
 
-#ifndef SIZEOF_HKEY
-/* used only here */
-#if defined(MS_WIN64)
-#  define SIZEOF_HKEY 8
-#elif defined(MS_WIN32)
-#  define SIZEOF_HKEY 4
-#else
-#  error "SIZEOF_HKEY is not defined"
-#endif
-#endif
-
-#ifndef REG_LEGAL_CHANGE_FILTER
-#define REG_LEGAL_CHANGE_FILTER        (\
-          REG_NOTIFY_CHANGE_NAME       |\
-          REG_NOTIFY_CHANGE_ATTRIBUTES |\
-          REG_NOTIFY_CHANGE_LAST_SET   |\
-          REG_NOTIFY_CHANGE_SECURITY   )
-#endif
-
 #if defined(MS_WINDOWS_DESKTOP) || defined(MS_WINDOWS_SYSTEM) || defined(MS_WINDOWS_GAMES)
 
 typedef struct {

--- a/configure.ac
+++ b/configure.ac
@@ -4633,13 +4633,6 @@ case $host in
     CFLAGS_NODIST="$CFLAGS_NODIST -D_WIN32_WINNT=0x0602";;
 esac
 
-# Determine if windows modules should be used.
-AC_SUBST(USE_WIN32_MODULE)
-USE_WIN32_MODULE='#'
-case $host in
-  *-*-mingw*) USE_WIN32_MODULE=;;
-esac
-
 # Templates for things AC_DEFINEd more than once.
 # For a single AC_DEFINE, no template is needed.
 AH_TEMPLATE([_REENTRANT],
@@ -8059,6 +8052,7 @@ PY_STDLIB_MOD([_hashlib], [], [test "$ac_cv_working_openssl_hashlib" = yes],
   [$OPENSSL_INCLUDES], [$OPENSSL_LDFLAGS $OPENSSL_LDFLAGS_RPATH $LIBCRYPTO_LIBS])
 
 dnl windows specific modules
+PY_STDLIB_MOD([winreg], [test "$MACHDEP" = "win32"])
 PY_STDLIB_MOD([msvcrt], [test "$MACHDEP" = "win32"])
 PY_STDLIB_MOD([_winapi], [test "$MACHDEP" = "win32"])
 PY_STDLIB_MOD([_msi], [test "$MACHDEP" = "win32"], [], [],


### PR DESCRIPTION
* REG_LEGAL_CHANGE_FILTER is part of mingw-w64 now
* SIZEOF_HKEY is defined already
* use the same build logic as with other win32 only modules

Needs to be merged into "Build winreg by default when compiling for MINGW"

Fixes #181
